### PR TITLE
[MCC-6] Alteração de namespace de entidades e ajuste na geração de prefixo das tabelas.

### DIFF
--- a/MeControla.Core.Tests/Configurations/Extensions/SetUpExtensionTests.cs
+++ b/MeControla.Core.Tests/Configurations/Extensions/SetUpExtensionTests.cs
@@ -1,13 +1,8 @@
 ﻿using FluentAssertions;
 using MeControla.Core.Configurations.Extensions;
 using MeControla.Core.IoC;
-using MeControla.Core.Tests.Datas.Mocks.Entities;
+using MeControla.Core.Tests.Mocks.Datas.Entities;
 using Microsoft.Extensions.DependencyInjection;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace MeControla.Core.Tests.Configurations.Extensions
@@ -31,7 +26,6 @@ namespace MeControla.Core.Tests.Configurations.Extensions
             serviceCollection.Should().HaveCount(1);
         }
     }
-
 
     public class InjectorTest : IInjector
     {

--- a/MeControla.Core.Tests/Extends/System/Text/Json/JsonSnakeCaseNamingPolicyTests.cs
+++ b/MeControla.Core.Tests/Extends/System/Text/Json/JsonSnakeCaseNamingPolicyTests.cs
@@ -1,6 +1,6 @@
 ﻿using FluentAssertions;
-using MeControla.Core.Tests.Datas.Mocks.Entities;
 using MeControla.Core.Tests.Mocks;
+using MeControla.Core.Tests.Mocks.Datas.Entities;
 using MeControla.Core.Tests.Mocks.Entities;
 using System.Text.Json;
 using Xunit;

--- a/MeControla.Core.Tests/Mocks/Datas/Entities/ClassTest.cs
+++ b/MeControla.Core.Tests/Mocks/Datas/Entities/ClassTest.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace MeControla.Core.Tests.Datas.Mocks.Entities
+namespace MeControla.Core.Tests.Mocks.Datas.Entities
 {
     public class ClassTest
     {

--- a/MeControla.Core.Tests/Mocks/Datas/Entities/ClassTestConfiguration.cs
+++ b/MeControla.Core.Tests/Mocks/Datas/Entities/ClassTestConfiguration.cs
@@ -1,4 +1,4 @@
-﻿namespace MeControla.Core.Tests.Datas.Mocks.Entities
+﻿namespace MeControla.Core.Tests.Mocks.Datas.Entities
 {
     public class ClassTestConfiguration : ClassTest
     { }

--- a/MeControla.Core.Tests/Mocks/Datas/Entities/Movie.cs
+++ b/MeControla.Core.Tests/Mocks/Datas/Entities/Movie.cs
@@ -1,0 +1,7 @@
+﻿namespace MeControla.Core.Tests.Mocks.Datas.Entities
+{
+    public class Movie
+    {
+        public int FieldInClass1 { get; set; }
+    }
+}

--- a/MeControla.Core.Tests/Mocks/Entities/ClassTestMock.cs
+++ b/MeControla.Core.Tests/Mocks/Entities/ClassTestMock.cs
@@ -1,4 +1,4 @@
-﻿using MeControla.Core.Tests.Datas.Mocks.Entities;
+﻿using MeControla.Core.Tests.Mocks.Datas.Entities;
 
 namespace MeControla.Core.Tests.Mocks.Entities
 {

--- a/MeControla.Core.Tests/Mocks/Primitives/IConfigurationMock.cs
+++ b/MeControla.Core.Tests/Mocks/Primitives/IConfigurationMock.cs
@@ -1,4 +1,4 @@
-﻿using MeControla.Core.Tests.Datas.Mocks.Entities;
+﻿using MeControla.Core.Tests.Mocks.Datas.Entities;
 using Microsoft.Extensions.Configuration;
 using System.Collections.Generic;
 

--- a/MeControla.Core.Tests/Tools/TableMetadataTests.cs
+++ b/MeControla.Core.Tests/Tools/TableMetadataTests.cs
@@ -1,5 +1,5 @@
 ﻿using FluentAssertions;
-using MeControla.Core.Tests.Datas.Mocks.Entities;
+using MeControla.Core.Tests.Mocks.Datas.Entities;
 using MeControla.Core.Tools;
 using Xunit;
 
@@ -39,17 +39,13 @@ namespace MeControla.Core.Tests.Tools
                 .BeEquivalentTo("cst_field_in_class1");
         }
 
-
-
         [Fact(DisplayName = "[TableMetadata.GetColumnName] Deve gerar o nome da columna utilizando o prefixo informado no construtor.")]
         public void DeveGerarNomeColunaDaPropriedadeComPrefixoInformado2()
         {
             var tool = new TableMetadata<Movie>("test_core");
             tool.GetColumnName(x => x.FieldInClass1)
                 .Should()
-                .BeEquivalentTo("mve");
+                .BeEquivalentTo("mve_field_in_class1");
         }
     }
-
-    public class Movie { public int FieldInClass1 { get; set; } }
 }

--- a/MeControla.Core.Tests/Tools/TableMetadataTests.cs
+++ b/MeControla.Core.Tests/Tools/TableMetadataTests.cs
@@ -38,5 +38,18 @@ namespace MeControla.Core.Tests.Tools
                 .Should()
                 .BeEquivalentTo("cst_field_in_class1");
         }
+
+
+
+        [Fact(DisplayName = "[TableMetadata.GetColumnName] Deve gerar o nome da columna utilizando o prefixo informado no construtor.")]
+        public void DeveGerarNomeColunaDaPropriedadeComPrefixoInformado2()
+        {
+            var tool = new TableMetadata<Movie>("test_core");
+            tool.GetColumnName(x => x.FieldInClass1)
+                .Should()
+                .BeEquivalentTo("mve");
+        }
     }
+
+    public class Movie { public int FieldInClass1 { get; set; } }
 }

--- a/MeControla.Core.Tests/Tools/TableMetadataTests.cs
+++ b/MeControla.Core.Tests/Tools/TableMetadataTests.cs
@@ -39,7 +39,7 @@ namespace MeControla.Core.Tests.Tools
                 .BeEquivalentTo("cst_field_in_class1");
         }
 
-        [Fact(DisplayName = "[TableMetadata.GetColumnName] Deve gerar o nome da columna utilizando o prefixo informado no construtor.")]
+        [Fact(DisplayName = "[TableMetadata.GetColumnName] Deve gerar o nome da columna utilizando o prefixo informado no construtor que contenha somente duas consoantes.")]
         public void DeveGerarNomeColunaDaPropriedadeComPrefixoInformado2()
         {
             var tool = new TableMetadata<Movie>("test_core");

--- a/MeControla.Core/Extensions/DataStorage/StringExtension.cs
+++ b/MeControla.Core/Extensions/DataStorage/StringExtension.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace MeControla.Core.Extensions.DataStorage
 {
@@ -22,7 +21,7 @@ namespace MeControla.Core.Extensions.DataStorage
 
             prefix = words.Length > 1
                    ? string.Concat(words.Select(x => x[0])).ToLower()
-                   : (valueTmp[0] + valueTmp[1..].GetConsonants())[..2];
+                   : $"{valueTmp[0]}{valueTmp[1..].GetConsonants()}"[..2];
 
             return prefix.ToLower();
         }
@@ -40,10 +39,16 @@ namespace MeControla.Core.Extensions.DataStorage
             {
                 >= 3 => valueTmp.GetUpperLetters(),
                 2 => string.Concat(words.Select(x => x[..1] + x[1..].GetConsonants()[..1])),
-                _ => (valueTmp[0] + valueTmp[1..].GetConsonants())[..3],
+                _ => $"{valueTmp[0]}{CheckSingleWord(valueTmp)}"[..3],
             };
 
             return prefix.ToLower();
+
+            static string CheckSingleWord(string word)
+            {
+                var prefix = word[1..].GetConsonants();
+                return prefix.Length == 1 ? $"{prefix}{word[^1]}" : prefix;
+            }
         }
     }
 }


### PR DESCRIPTION
- Duas entidades estavam com o namespace errado e foram corrigidas.
- O método que gera o prefixo para o nome das tabelas, não estava atendendo a situação em que o nome da tabela tem somente duas consoantes no nome.