### PR TITLE
[MCC-9] Adicionado InputFilterMapper e DbContextFactory

### DIFF
--- a/MeControla.Core/Mappers/IInputDtoToFilterEntityMapper.cs
+++ b/MeControla.Core/Mappers/IInputDtoToFilterEntityMapper.cs
@@ -1,0 +1,10 @@
+﻿using MeControla.Core.Data.Dtos;
+using MeControla.Core.Data.Entities;
+
+namespace MeControla.Core.Mappers
+{
+    public interface IInputDtoToFilterEntityMapper<TParam, TResult> : IMapper<TParam, TResult>
+        where TParam : class, IInputDto
+        where TResult : class, IFilterEntity
+    { }
+}

--- a/MeControla.Core/MeControla.Core.csproj
+++ b/MeControla.Core/MeControla.Core.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="12.0.1" />
+    <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />

--- a/MeControla.Core/Repositories/BaseDbContextFactory.cs
+++ b/MeControla.Core/Repositories/BaseDbContextFactory.cs
@@ -7,7 +7,7 @@ namespace MeControla.Core.Repositories
 {
     public abstract class BaseDbContextFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TDbContext>
         : IDesignTimeDbContextFactory<TDbContext>, IDisposable
-        where TDbContext : DbContext, new()
+        where TDbContext : DbContext
     {
         private TDbContext context;
 


### PR DESCRIPTION
Adicionado interface para mapeamento entre input de filter e ajustado classe base do factory para criar as Migrations.