### PR TITLE
[MCC-13] Atualização dependências e refatoração de construtores

### DIFF
--- a/MeControla.Core.Tests/MeControla.Core.Tests.csproj
+++ b/MeControla.Core.Tests/MeControla.Core.Tests.csproj
@@ -6,29 +6,29 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.1">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="ReportGenerator" Version="5.2.1" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="ReportGenerator" Version="5.2.5" />
+    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.1">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="XunitXml.TestLogger" Version="3.1.20" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.4" />
     <PackageReference Include="NSubstituteEquivalency" Version="2.0.0" />
   </ItemGroup>
 

--- a/MeControla.Core.Tests/Repositories/BaseAsyncRepositoryTests.cs
+++ b/MeControla.Core.Tests/Repositories/BaseAsyncRepositoryTests.cs
@@ -3,6 +3,7 @@ using MeControla.Core.Tests.Mocks;
 using MeControla.Core.Tests.Mocks.Datas.Repositories;
 using MeControla.Core.Tests.Mocks.Entities;
 using MeControla.Core.Tests.Mocks.Repositories;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace MeControla.Core.Tests.Repositories
@@ -17,21 +18,21 @@ namespace MeControla.Core.Tests.Repositories
             => userRepository = new UserRepository(context);
 
         [Fact(DisplayName = "[BaseAsyncRepository.CountAsync] Deve retornar a quantidade total de registros na tabela do banco de dados.")]
-        public async void DeveListarTodosUsuarios()
+        public async Task DeveListarTodosUsuarios()
         {
             var actual = await userRepository.CountAsync(GetCancellationToken());
             actual.Should().Be(TOTAL_USERS);
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.CountAsync] Deve retornar a quantidade total de registros na tabela do banco de dados que coincidem com o criterio.")]
-        public async void DeveListarTodosUsuariosDaCondicao()
+        public async Task DeveListarTodosUsuariosDaCondicao()
         {
             var actual = await userRepository.CountAsync(entity => entity.Id == DataMock.INT_ID_1, GetCancellationToken());
             actual.Should().Be(1);
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.CreateAsync] Deve criar um usuario na tabela do banco de dados.")]
-        public async void DeveCriarUsuario()
+        public async Task DeveCriarUsuario()
         {
             var user = UserMock.CreateUser4();
             user.Id = 0;
@@ -43,7 +44,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.UpdateAsync] Deve atualizar um usuario na tabela do banco de dados.")]
-        public async void DeveAtualizarUsuario()
+        public async Task DeveAtualizarUsuario()
         {
             var expected = UserMock.CreateUser3();
             expected.Name = DataMock.TEXT_USER_NAME_4;
@@ -56,7 +57,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.RemoveAsync] Deve remover um usuario na tabela do banco de dados.")]
-        public async void DeveRemoverUsuario()
+        public async Task DeveRemoverUsuario()
         {
             var user = UserMock.CreateUser3();
 
@@ -67,7 +68,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.FindAllPagedAsync] Deve retornar lista paginada dos registros que existir na tabela do banco de dados.")]
-        public async void DeveRetornarListaPaginadaComRegistros()
+        public async Task DeveRetornarListaPaginadaComRegistros()
         {
             var pagination = PaginationFilterMock.CreatePage1();
 
@@ -78,7 +79,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.FindAllPagedAsync] Deve retornar lista paginada de todos os registros que exitir na tabela do banco de dados que coincidem com o criterio informado.")]
-        public async void DeveRetornarListaPaginadaComRegistrosQuandoCriterioAtendido()
+        public async Task DeveRetornarListaPaginadaComRegistrosQuandoCriterioAtendido()
         {
             var pagination = PaginationFilterMock.CreatePage1();
 
@@ -89,7 +90,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.FindAllPagedAsync] Deve retornar lista paginada vazia quando existir registro que não coincidem com o criterio informado.")]
-        public async void DeveRetornarListaPaginadaSemRegistrosQuandoCriterioNaoAtendido()
+        public async Task DeveRetornarListaPaginadaSemRegistrosQuandoCriterioNaoAtendido()
         {
             var pagination = PaginationFilterMock.CreatePage1();
 
@@ -99,7 +100,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.FindAllAsync] Deve retornar lista de todos os registro que existir na tabela do banco de dados.")]
-        public async void DeveRetornarListaRegistros()
+        public async Task DeveRetornarListaRegistros()
         {
             var actual = await userRepository.FindAllAsync(GetCancellationToken());
 
@@ -108,7 +109,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.FindAllAsync] Deve retornar lista de todos os registro que exitir na tabela do banco de dados que coincidem com o criterio informado.")]
-        public async void DeveRetornarListaRegistrosQuandoCriterioAtendido()
+        public async Task DeveRetornarListaRegistrosQuandoCriterioAtendido()
         {
             var actual = await userRepository.FindAllAsync(entity => entity.Id < DataMock.INT_ID_4, GetCancellationToken());
 
@@ -117,7 +118,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.FindAllAsync] Deve retornar lista vazia quando existir registro que não coincidem com o criterio informado.")]
-        public async void DeveRetornarListaVaziaQuandoCriterioNaoAtendido()
+        public async Task DeveRetornarListaVaziaQuandoCriterioNaoAtendido()
         {
             var actual = await userRepository.FindAllAsync(entity => entity.Id >= DataMock.INT_ID_4, GetCancellationToken());
 
@@ -125,7 +126,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.FindAsync] Deve retornar objeto se exitir na tabela do banco de dados algum registro que conincida com o Id.")]
-        public async void DeveRetornarObjetoQuandoIdInformado()
+        public async Task DeveRetornarObjetoQuandoIdInformado()
         {
             var expected = UserMock.CreateUser3();
             var actual = await userRepository.FindAsync(expected.Id, GetCancellationToken());
@@ -135,7 +136,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.FindAsync] Deve retornar null não se exitir na tabela do banco de dados algum registro que conincida com o Id.")]
-        public async void DeveRetornarNullQuandoIdInformado()
+        public async Task DeveRetornarNullQuandoIdInformado()
         {
             var exist = await userRepository.FindAsync(DataMock.INT_ID_4, GetCancellationToken());
 
@@ -143,7 +144,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.FindAsync] Deve retornar objeto se exitir na tabela do banco de dados algum registro que conincida com o Guid.")]
-        public async void DeveRetornarObjetoQuandoGuidInformado()
+        public async Task DeveRetornarObjetoQuandoGuidInformado()
         {
             var expected = UserMock.CreateUser3();
             var actual = await userRepository.FindAsync(expected.Uuid, GetCancellationToken());
@@ -153,7 +154,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.FindAsync] Deve retornar null não se exitir na tabela do banco de dados algum registro que conincida com o Guid.")]
-        public async void DeveRetornarNullQuandoGuidInformado()
+        public async Task DeveRetornarNullQuandoGuidInformado()
         {
             var exist = await userRepository.FindAsync(DataMock.UUID_USER_4, GetCancellationToken());
 
@@ -161,7 +162,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.FindAsync] Deve retornar objeto se exitir na tabela do banco de dados algum registro que conincida com o criterio.")]
-        public async void DeveRetornarObjetoQuandoCriteriaComCoincidencia()
+        public async Task DeveRetornarObjetoQuandoCriteriaComCoincidencia()
         {
             var expected = UserMock.CreateUser3();
             var actual = await userRepository.FindAsync(entity => entity.Uuid == expected.Uuid, GetCancellationToken());
@@ -171,7 +172,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.FindAsync] Deve retornar null não se exitir na tabela do banco de dados algum registro que conincida com o criterio.")]
-        public async void DeveRetornarNullQuandoCriteriaSemCoincidencia()
+        public async Task DeveRetornarNullQuandoCriteriaSemCoincidencia()
         {
             var exist = await userRepository.FindAsync(entity => entity.Uuid == DataMock.UUID_USER_4, GetCancellationToken());
 
@@ -179,7 +180,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.ExistsAsync] Deve retornar true se exitir na tabela do banco de dados algum registro que conincida com o Id.")]
-        public async void DeveRetornarTrueQuandoIdInformado()
+        public async Task DeveRetornarTrueQuandoIdInformado()
         {
             var exist = await userRepository.ExistsAsync(DataMock.INT_ID_3, GetCancellationToken());
 
@@ -187,7 +188,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.ExistsAsync] Deve retornar false não se exitir na tabela do banco de dados algum registro que conincida com o Id.")]
-        public async void DeveRetornarFalseQuandoIdInformado()
+        public async Task DeveRetornarFalseQuandoIdInformado()
         {
             var exist = await userRepository.ExistsAsync(DataMock.INT_ID_4, GetCancellationToken());
 
@@ -195,7 +196,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.ExistsAsync] Deve retornar true se exitir na tabela do banco de dados algum registro que conincida com o Guid.")]
-        public async void DeveRetornarTrueQuandoGuidInformado()
+        public async Task DeveRetornarTrueQuandoGuidInformado()
         {
             var exist = await userRepository.ExistsAsync(DataMock.UUID_USER_3, GetCancellationToken());
 
@@ -203,7 +204,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.ExistsAsync] Deve retornar false não se exitir na tabela do banco de dados algum registro que conincida com o Guid.")]
-        public async void DeveRetornarFalseQuandoGuidInformado()
+        public async Task DeveRetornarFalseQuandoGuidInformado()
         {
             var exist = await userRepository.ExistsAsync(DataMock.UUID_USER_4, GetCancellationToken());
 
@@ -211,7 +212,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.ExistsAsync] Deve retornar true se exitir na tabela do banco de dados algum registro que conincida com o criterio.")]
-        public async void DeveRetornarTrueQuandoCriteriaInformado()
+        public async Task DeveRetornarTrueQuandoCriteriaInformado()
         {
             var exist = await userRepository.ExistsAsync(entity => entity.Uuid == DataMock.UUID_USER_3, GetCancellationToken());
 
@@ -219,7 +220,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseAsyncRepository.ExistsAsync] Deve retornar false não se exitir na tabela do banco de dados algum registro que conincida com o criterio.")]
-        public async void DeveRetornarFalseQuandoCriteriaInformado()
+        public async Task DeveRetornarFalseQuandoCriteriaInformado()
         {
             var exist = await userRepository.ExistsAsync(entity => entity.Uuid == DataMock.UUID_USER_4, GetCancellationToken());
 

--- a/MeControla.Core.Tests/Repositories/BaseDbContextFactoryTests.cs
+++ b/MeControla.Core.Tests/Repositories/BaseDbContextFactoryTests.cs
@@ -15,6 +15,15 @@ namespace MeControla.Core.Tests.Repositories
                 => options.UseSqlite("DataSource=:memory:");
         }
 
+        private class TestDbContextNullFactory : BaseDbContextFactory<DbAppContext>
+        {
+            protected override void Configure(DbContextOptionsBuilder<DbAppContext> options)
+            { }
+
+            protected override DbAppContext CreateInstanceDbContext(DbContextOptionsBuilder<DbAppContext> optionsBuilder)
+                => null;
+        }
+
         [Fact(DisplayName = "[BaseDbContextFactory.CreateDbContext|Dispose] Cria DbAppContext a través da implementação do BaseDbContextFactory e ao final utiliza o dispose para finalizar o contexto.")]
         public void CreateDbContext_ShouldCreateDbContextWithConfiguredOptions()
         {
@@ -31,6 +40,18 @@ namespace MeControla.Core.Tests.Repositories
 
             var act = () => dbContext.Database;
             act.Should().Throw<ObjectDisposedException>();
+        }
+
+        [Fact(DisplayName = "[BaseDbContextFactory.CreateDbContext|Dispose] Cria DbAppContext a través da implementação do BaseDbContextFactory e executar dispose quando context for null.")]
+        public void Dispose_ShouldDisposeDbContext()
+        {
+            var factory = new TestDbContextNullFactory();
+            var context = factory.CreateDbContext([]);
+
+            factory.Dispose();
+
+            var dbContext = context as DbContext;
+            dbContext.Should().BeNull();
         }
     }
 }

--- a/MeControla.Core.Tests/Repositories/BaseDbContextFactoryTests.cs
+++ b/MeControla.Core.Tests/Repositories/BaseDbContextFactoryTests.cs
@@ -15,6 +15,7 @@ namespace MeControla.Core.Tests.Repositories
                 => options.UseSqlite("DataSource=:memory:");
         }
 
+#if DEBUG
         private class TestDbContextNullFactory : BaseDbContextFactory<DbAppContext>
         {
             protected override void Configure(DbContextOptionsBuilder<DbAppContext> options)
@@ -23,6 +24,7 @@ namespace MeControla.Core.Tests.Repositories
             protected override DbAppContext CreateInstanceDbContext(DbContextOptionsBuilder<DbAppContext> optionsBuilder)
                 => null;
         }
+#endif
 
         [Fact(DisplayName = "[BaseDbContextFactory.CreateDbContext|Dispose] Cria DbAppContext a través da implementação do BaseDbContextFactory e ao final utiliza o dispose para finalizar o contexto.")]
         public void CreateDbContext_ShouldCreateDbContextWithConfiguredOptions()
@@ -42,6 +44,7 @@ namespace MeControla.Core.Tests.Repositories
             act.Should().Throw<ObjectDisposedException>();
         }
 
+#if DEBUG
         [Fact(DisplayName = "[BaseDbContextFactory.CreateDbContext|Dispose] Cria DbAppContext a través da implementação do BaseDbContextFactory e executar dispose quando context for null.")]
         public void Dispose_ShouldDisposeDbContext()
         {
@@ -53,5 +56,6 @@ namespace MeControla.Core.Tests.Repositories
             var dbContext = context as DbContext;
             dbContext.Should().BeNull();
         }
+#endif
     }
 }

--- a/MeControla.Core.Tests/Repositories/BaseFilterAsyncRepositoryTests.cs
+++ b/MeControla.Core.Tests/Repositories/BaseFilterAsyncRepositoryTests.cs
@@ -2,6 +2,7 @@
 using MeControla.Core.Tests.Mocks.Datas.Repositories;
 using MeControla.Core.Tests.Mocks.Filters;
 using MeControla.Core.Tests.Mocks.Repositories;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace MeControla.Core.Tests.Repositories
@@ -14,7 +15,7 @@ namespace MeControla.Core.Tests.Repositories
             => workTaskRepository = new WorkTaskRepository(context);
 
         [Fact(DisplayName = "[BaseFilterAsyncRepository.FindFilterAllAsync] Deve implementar o método FindFilterAllAsync para realizar a filtragem das informações.")]
-        public async void FindFilterAllAsync_ShouldReturnListOfEntities()
+        public async Task FindFilterAllAsync_ShouldReturnListOfEntities()
         {
             var actual = await workTaskRepository.FindFilterAllAsync(WorkTaskFilterMock.CreateEmpty(), GetCancellationToken());
 

--- a/MeControla.Core.Tests/Repositories/BaseManyAsyncRepositoryTests.cs
+++ b/MeControla.Core.Tests/Repositories/BaseManyAsyncRepositoryTests.cs
@@ -2,6 +2,7 @@
 using MeControla.Core.Tests.Mocks.Datas.Repositories;
 using MeControla.Core.Tests.Mocks.Entities;
 using MeControla.Core.Tests.Mocks.Repositories;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace MeControla.Core.Tests.Repositories
@@ -14,7 +15,7 @@ namespace MeControla.Core.Tests.Repositories
             => userPermissionRepository = new UserPermissionRepository(context);
 
         [Fact(DisplayName = "[BaseManyAsyncRepository.CreateAsync] Deve relacionar a permissão de usuário ao usuario 3 na tabela do banco de dados.")]
-        public async void DeveRelacionarPermissaoAdministradorUsuario3()
+        public async Task DeveRelacionarPermissaoAdministradorUsuario3()
         {
             var userPermission = UserPermissionMock.CreateUser3User();
 
@@ -26,7 +27,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseManyAsyncRepository.RemoveAsync] Deve desrelacionar a permissão de usuário ao usuario 2 na tabela do banco de dados.")]
-        public async void DeveDesrelacionarPermissaoUsuarioUsuario2()
+        public async Task DeveDesrelacionarPermissaoUsuarioUsuario2()
         {
             var userPermission = UserPermissionMock.CreateUser2User();
 
@@ -38,7 +39,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[BaseManyAsyncRepository.ExistsAsync] Deve chegar se o usuário 1 possui permissão de administrador relacionada.")]
-        public async void DeveRetornarTrueQuandoExistirRelacao()
+        public async Task DeveRetornarTrueQuandoExistirRelacao()
         {
             var userPermission = UserPermissionMock.CreateUser1Administrator();
 

--- a/MeControla.Core.Tests/Repositories/DbContextFacadeTests.cs
+++ b/MeControla.Core.Tests/Repositories/DbContextFacadeTests.cs
@@ -6,6 +6,7 @@ using MeControla.Core.Tests.Mocks.Entities;
 using MeControla.Core.Tests.Mocks.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace MeControla.Core.Tests.Repositories
@@ -70,7 +71,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[DbContextFacade.BeginTransactionAsync] Deve retornar o mesmo valor que a instancia original.")]
-        public async void DeveGerarBeginTransactionAsync()
+        public async Task DeveGerarBeginTransactionAsync()
         {
             await dbContextFacade.BeginTransactionAsync();
 
@@ -80,7 +81,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[DbContextFacade.CommitTransaction] Deve retornar o mesmo valor que a instancia original.")]
-        public async void DeveGerarCommitTransaction()
+        public async Task DeveGerarCommitTransaction()
         {
             var cancellationToken = GetCancellationToken();
             var repository = new UserRepository(context);
@@ -98,7 +99,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[DbContextFacade.CommitTransactionAsync] Deve retornar o mesmo valor que a instancia original.")]
-        public async void DeveGerarCommitTransactionAsync()
+        public async Task DeveGerarCommitTransactionAsync()
         {
             var cancellationToken = GetCancellationToken();
             var repository = new UserRepository(context);
@@ -116,7 +117,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[DbContextFacade.RollbackTransaction] Deve retornar o mesmo valor que a instancia original.")]
-        public async void DeveGerarRollbackTransaction()
+        public async Task DeveGerarRollbackTransaction()
         {
             var cancellationToken = GetCancellationToken();
             var repository = new UserRepository(context);
@@ -134,7 +135,7 @@ namespace MeControla.Core.Tests.Repositories
         }
 
         [Fact(DisplayName = "[DbContextFacade.RollbackTransactionAsync] Deve retornar o mesmo valor que a instancia original.")]
-        public async void DeveGerarRollbackTransactionAsync()
+        public async Task DeveGerarRollbackTransactionAsync()
         {
             var cancellationToken = GetCancellationToken();
             var repository = new UserRepository(context);

--- a/MeControla.Core/MeControla.Core.csproj
+++ b/MeControla.Core/MeControla.Core.csproj
@@ -37,9 +37,9 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MeControla.Core/Repositories/BaseAsyncRepository.cs
+++ b/MeControla.Core/Repositories/BaseAsyncRepository.cs
@@ -11,14 +11,10 @@ using System.Threading.Tasks;
 
 namespace MeControla.Core.Repositories
 {
-    public abstract class BaseAsyncRepository<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TEntity>
-        : ContextRepository<TEntity>, IAsyncRepository<TEntity>
+    public abstract class BaseAsyncRepository<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TEntity>(IDbContext context, DbSet<TEntity> dbSet)
+        : ContextRepository<TEntity>(context, dbSet), IAsyncRepository<TEntity>
          where TEntity : class, IEntity
     {
-        protected BaseAsyncRepository(IDbContext context, DbSet<TEntity> dbSet)
-            : base(context, dbSet)
-        { }
-
         public virtual async Task<long> CountAsync(CancellationToken cancellationToken)
             => await dbSet.LongCountAsync(cancellationToken);
 

--- a/MeControla.Core/Repositories/BaseDbContextFactory.cs
+++ b/MeControla.Core/Repositories/BaseDbContextFactory.cs
@@ -21,10 +21,18 @@ namespace MeControla.Core.Repositories
 
             Configure(optionsBuilder);
 
-            context = (TDbContext)Activator.CreateInstance(typeof(TDbContext), [optionsBuilder.Options]);
+            context = CreateInstanceDbContext(optionsBuilder);
 
             return context;
         }
+
+#if DEBUG
+        protected virtual
+#else
+        private static
+#endif
+        TDbContext CreateInstanceDbContext(DbContextOptionsBuilder<TDbContext> optionsBuilder)
+           => (TDbContext)Activator.CreateInstance(typeof(TDbContext), [optionsBuilder.Options]);
 
         protected abstract void Configure(DbContextOptionsBuilder<TDbContext> options);
 

--- a/MeControla.Core/Repositories/BaseFilterAsyncRepository.cs
+++ b/MeControla.Core/Repositories/BaseFilterAsyncRepository.cs
@@ -7,15 +7,11 @@ using System.Threading.Tasks;
 
 namespace MeControla.Core.Repositories
 {
-    public abstract class BaseFilterAsyncRepository<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TEntity, TFilterEntity>
-        : BaseAsyncRepository<TEntity>, IFilterAsyncRepository<TEntity, TFilterEntity>
+    public abstract class BaseFilterAsyncRepository<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TEntity, TFilterEntity>(IDbContext context, DbSet<TEntity> dbSet)
+        : BaseAsyncRepository<TEntity>(context, dbSet), IFilterAsyncRepository<TEntity, TFilterEntity>
         where TEntity : class, IEntity
         where TFilterEntity : class, IFilterEntity
     {
-        protected BaseFilterAsyncRepository(IDbContext context, DbSet<TEntity> dbSet)
-            : base(context, dbSet)
-        { }
-
         public abstract Task<IList<TEntity>> FindFilterAllAsync(TFilterEntity filter, CancellationToken cancellationToken);
     }
 }

--- a/MeControla.Core/Repositories/ContextRepository.cs
+++ b/MeControla.Core/Repositories/ContextRepository.cs
@@ -12,6 +12,7 @@ namespace MeControla.Core.Repositories
 
         private DbContextFacade database;
 
+        [SuppressMessage("Style", "IDE0290:Use primary constructor", Justification = "Constructor to be protected.")]
         protected ContextRepository([NotNull] IDbContext context, [NotNull] DbSet<TEntity> dbSet)
         {
             this.context = context;


### PR DESCRIPTION
Realização das seguintes alterações:
- Atualização para a versão mais recente das dependências do projeto;
- Alterar os construtores para primary construtor relatados nas mensagens do Visual Studio;
- Cobertura do teste do BaseDbContextFactory para cobrir condição em que ao executar o dispose da classe, não acionar o dispose do context quando o context for null;