### PR TITLE
[MCC-17] Correção Code Smell, Pipeline remoção artefatos antigos e Extensão do IValidator

### DIFF
--- a/.github/workflows/delete-artifacts.yml
+++ b/.github/workflows/delete-artifacts.yml
@@ -1,0 +1,14 @@
+name: Delete Artifacts
+
+on:
+  schedule:
+    - cron: '0 4 * * *' # every day at 4 AM UTC
+
+jobs:
+  delete-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kolpav/purge-artifacts-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          expire-in: 30days # Setting this value to 0 will delete all artifacts

--- a/src/MeControla.Core/Data/Entities/IForeignKeysManyEntity.cs
+++ b/src/MeControla.Core/Data/Entities/IForeignKeysManyEntity.cs
@@ -1,0 +1,8 @@
+﻿namespace MeControla.Core.Data.Entities
+{
+    public interface IForeignKeysManyEntity
+    {
+        long RootId { get; set; }
+        long TargetId { get; set; }
+    }
+}

--- a/src/MeControla.Core/Data/Entities/IManyEntity.cs
+++ b/src/MeControla.Core/Data/Entities/IManyEntity.cs
@@ -1,11 +1,9 @@
 ﻿namespace MeControla.Core.Data.Entities
 {
-    public interface IManyEntity<TRoot, TTarget>
+    public interface IManyEntity<TRoot, TTarget> : IForeignKeysManyEntity
         where TRoot : IEntity
         where TTarget : IEntity
     {
-        long RootId { get; set; }
-        long TargetId { get; set; }
         TRoot Root { get; set; }
         TTarget Target { get; set; }
     }

--- a/src/MeControla.Core/Extensions/IValidatorExtensions.cs
+++ b/src/MeControla.Core/Extensions/IValidatorExtensions.cs
@@ -1,0 +1,31 @@
+﻿using FluentValidation;
+using MeControla.Core.Data.Dtos;
+using MeControla.Core.Data.Entities;
+using MeControla.Core.Exceptions;
+using System;
+
+namespace MeControla.Core.Extensions
+{
+#if !DEBUG
+    [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+#endif
+    public static class IValidatorExtensions
+    {
+#if !DEBUG
+        [System.Diagnostics.DebuggerStepThrough]
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+#endif
+        public static void ThrowIfInvalid<TEntity, TInputDto>(this IValidator<TInputDto> validator, TInputDto input)
+            where TEntity : class, IEntity
+            where TInputDto : class, IInputDto
+        {
+            ArgumentNullException.ThrowIfNull(validator);
+
+            var result = validator.Validate(input);
+            if (result.IsValid)
+                return;
+
+            throw new FormValidationException(typeof(TEntity), result);
+        }
+    }
+}

--- a/src/MeControla.Core/Extensions/IValidatorExtensions.cs
+++ b/src/MeControla.Core/Extensions/IValidatorExtensions.cs
@@ -7,7 +7,7 @@ using System;
 namespace MeControla.Core.Extensions
 {
 #if !DEBUG
-    [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+    [System.Diagnostics.DebuggerStepThrough]
 #endif
     public static class IValidatorExtensions
     {

--- a/src/MeControla.Core/Repositories/BaseManyAsyncRepository.cs
+++ b/src/MeControla.Core/Repositories/BaseManyAsyncRepository.cs
@@ -8,11 +8,9 @@ using System.Threading.Tasks;
 
 namespace MeControla.Core.Repositories
 {
-    public class BaseManyAsyncRepository<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TEntity, TRoot, TTarget>
-        : IManyAsyncRepository<TEntity, TRoot, TTarget>
-        where TEntity : class, IManyEntity<TRoot, TTarget>
-        where TRoot : IEntity
-        where TTarget : IEntity
+    public class BaseManyAsyncRepository<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TEntity>
+        : IManyAsyncRepository<TEntity>
+        where TEntity : class, IForeignKeysManyEntity
     {
         protected readonly IDbContext context;
 

--- a/src/MeControla.Core/Repositories/IManyAsyncRepository.cs
+++ b/src/MeControla.Core/Repositories/IManyAsyncRepository.cs
@@ -5,10 +5,8 @@ using System.Threading.Tasks;
 
 namespace MeControla.Core.Repositories
 {
-    public interface IManyAsyncRepository<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TEntity, TRoot, TTarget>
-       where TEntity : IManyEntity<TRoot, TTarget>
-       where TRoot : IEntity
-       where TTarget : IEntity
+    public interface IManyAsyncRepository<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TEntity>
+       where TEntity : IForeignKeysManyEntity
     {
         Task<bool> CreateAsync(TEntity obj, CancellationToken cancellationToken);
         Task<bool> RemoveAsync(TEntity obj, CancellationToken cancellationToken);

--- a/test/MeControla.Core.Tests/Extensions/IValidatorExtensionsTests.cs
+++ b/test/MeControla.Core.Tests/Extensions/IValidatorExtensionsTests.cs
@@ -1,0 +1,45 @@
+﻿using FluentAssertions;
+using MeControla.Core.Exceptions;
+using MeControla.Core.Extensions;
+using MeControla.Core.Tests.Mocks.Datas.Entities;
+using MeControla.Core.Tests.Mocks.Datas.InputDtos;
+using MeControla.Core.Tests.Mocks.InputDtos;
+using MeControla.Core.Tests.Mocks.Validators;
+using System;
+using Xunit;
+
+namespace MeControla.Core.Tests.Extensions
+{
+    public class IValidatorExtensionsTests
+    {
+        [Fact(DisplayName = "[IValidatorExtensions.ThrowIfInvalid] Deve gerar exceção quando o IValidator for null.")]
+        public void DeveGerarExcecaoQuandoValidatorNull()
+        {
+            var validator = (UserInputDtoValidator)null;
+
+            var act = () => validator.ThrowIfInvalid<User, UserInputDto>(UserInputDtoMock.CreateUser1());
+            act.Should().Throw<ArgumentNullException>();
+            act.Should().NotThrow<FormValidationException>();
+        }
+
+        [Fact(DisplayName = "[IValidatorExtensions.ThrowIfInvalid] Deve gerar exceção quando o InputDto for inválido.")]
+        public void DeveGerarExcecaoQuandoInputDtoInvalido()
+        {
+            var validator = new UserInputDtoValidator();
+
+            var act = () => validator.ThrowIfInvalid<User, UserInputDto>(UserInputDtoMock.CreateEmpty());
+            act.Should().NotThrow<ArgumentNullException>();
+            act.Should().Throw<FormValidationException>();
+        }
+
+        [Fact(DisplayName = "[IValidatorExtensions.ThrowIfInvalid] Deve finalizar quando o IValidator validar InputDto e não gerar exceção.")]
+        public void DeveFinalizarQuandoInputDtoValido()
+        {
+            var validator = new UserInputDtoValidator();
+
+            var act = () => validator.ThrowIfInvalid<User, UserInputDto>(UserInputDtoMock.CreateUser1());
+            act.Should().NotThrow<ArgumentNullException>();
+            act.Should().NotThrow<FormValidationException>();
+        }
+    }
+}

--- a/test/MeControla.Core.Tests/Mocks/Datas/InputDtos/UserInputDto.cs
+++ b/test/MeControla.Core.Tests/Mocks/Datas/InputDtos/UserInputDto.cs
@@ -1,0 +1,9 @@
+﻿using MeControla.Core.Data.Dtos;
+
+namespace MeControla.Core.Tests.Mocks.Datas.InputDtos
+{
+    public class UserInputDto : IInputDto
+    {
+        public string Name { get; set; }
+    }
+}

--- a/test/MeControla.Core.Tests/Mocks/Datas/Repositories/IUserPermissionRepository.cs
+++ b/test/MeControla.Core.Tests/Mocks/Datas/Repositories/IUserPermissionRepository.cs
@@ -3,6 +3,6 @@ using MeControla.Core.Tests.Mocks.Datas.Entities;
 
 namespace MeControla.Core.Tests.Mocks.Datas.Repositories
 {
-    public interface IUserPermissionRepository : IManyAsyncRepository<UserPermission, User, Permission>
+    public interface IUserPermissionRepository : IManyAsyncRepository<UserPermission>
     { }
 }

--- a/test/MeControla.Core.Tests/Mocks/Datas/Repositories/UserPermissionRepository.cs
+++ b/test/MeControla.Core.Tests/Mocks/Datas/Repositories/UserPermissionRepository.cs
@@ -4,6 +4,6 @@ using MeControla.Core.Tests.Mocks.Datas.Entities;
 namespace MeControla.Core.Tests.Mocks.Datas.Repositories
 {
     public class UserPermissionRepository(IDbAppContext context)
-        : BaseManyAsyncRepository<UserPermission, User, Permission>(context, context.UserPermissions), IUserPermissionRepository
+        : BaseManyAsyncRepository<UserPermission>(context, context.UserPermissions), IUserPermissionRepository
     { }
 }

--- a/test/MeControla.Core.Tests/Mocks/InputDtos/UserInputDtoMock.cs
+++ b/test/MeControla.Core.Tests/Mocks/InputDtos/UserInputDtoMock.cs
@@ -1,0 +1,16 @@
+﻿using MeControla.Core.Tests.Mocks.Datas.InputDtos;
+
+namespace MeControla.Core.Tests.Mocks.InputDtos
+{
+    public static class UserInputDtoMock
+    {
+        public static UserInputDto CreateEmpty()
+            => new();
+
+        public static UserInputDto CreateUser1()
+            => new()
+            {
+                Name = DataMock.TEXT_USER_NAME_1
+            };
+    }
+}

--- a/test/MeControla.Core.Tests/Mocks/Validators/UserInputDtoValidator.cs
+++ b/test/MeControla.Core.Tests/Mocks/Validators/UserInputDtoValidator.cs
@@ -1,0 +1,20 @@
+﻿using FluentValidation;
+using MeControla.Core.Tests.Mocks.Datas.InputDtos;
+
+namespace MeControla.Core.Tests.Mocks.Validators
+{
+    public class UserInputDtoValidator : AbstractValidator<UserInputDto>, IValidator<UserInputDto>
+    {
+        public const string FIELD_NAME_REQUIRED = "Name is required.";
+        public const string FIELD_NAME_BETWEENLENGTH = "Name should be between 5 and 100 chars";
+
+        public UserInputDtoValidator()
+        {
+            RuleFor(x => x.Name).Cascade(CascadeMode.Stop)
+                                .NotEmpty()
+                                .WithMessage(FIELD_NAME_REQUIRED)
+                                .Must(x => x.Length > 5 && x.Length < 100)
+                                .WithMessage(FIELD_NAME_BETWEENLENGTH);
+        }
+    }
+}


### PR DESCRIPTION
Alterações:
- Adicionado extensão para o IValidator e gerar exceção quando o InputDto for inválido.
- Modificado o IManyEntity para que as classes base do Repository terem no máximo dois parâmetros genéricos e resolver code smell do SonarCloud.
- Adicionado pipeline que remove artefatos antigos que estão armazenados a mais de 30 dias.