### PR TITLE
[MCC-20] Resolver problema de pipeline e code smells

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,4 +55,4 @@ jobs:
       run: dotnet publish --nologo -c ${{ matrix.build-configuration }} -p:DebugType=None -p:DebugSymbols=false -p:Optimize=true -p:AssemblyVersion=${{ env.app-version }} -p:FileVersion=${{ env.app-version }} -p:Version=${{ env.app-version }}
       
     - name: Push to NuGet
-      run: dotnet nuget push "./${{ matrix.app-namespace }}/bin/Release/${{ matrix.app-namespace }}.${{ env.app-version }}.nupkg" --api-key ${{secrets.NUGET_TOKEN}} --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push "./src/${{ matrix.app-namespace }}/bin/Release/${{ matrix.app-namespace }}.${{ env.app-version }}.nupkg" --api-key ${{secrets.NUGET_TOKEN}} --source https://api.nuget.org/v3/index.json

--- a/src/MeControla.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/MeControla.Core/Extensions/ConfigurationExtensions.cs
@@ -59,7 +59,7 @@ namespace MeControla.Core.Extensions
                 node = node[section];
             }
 
-            node![sections.Last()] = JsonValue.Create(value);
+            node![sections[^1]] = JsonValue.Create(value);
 
             string output = jsonObj.ToJsonString(GetJsonOptions());
 


### PR DESCRIPTION
Resolver problema na pipeline de publicação do pacote, devido a alteração da estrutura de pastas, não foi alterado o caminho para pegar o artefato gerado pelo build e realizar o upload para o Nuget.
Além disso, resolver o problema do Code Smell existente.